### PR TITLE
Support serialization of recursive functions with dump_func()

### DIFF
--- a/dpark/serialize.py
+++ b/dpark/serialize.py
@@ -1,6 +1,16 @@
 import marshal, new, cPickle
 import itertools
 
+class RecursiveFunctionPlaceholder(object):
+    """
+    Placeholder for a recursive reference to the current function,
+    to avoid infinite recursion when serializing recursive functions.
+    """
+    def __eq__(self, other):
+        return isinstance(other, RecursiveFunctionPlaceholder)
+
+RECURSIVE_FUNCTION_PLACEHOLDER = RecursiveFunctionPlaceholder()
+
 def marshalable(o):
     if o is None: return True
     t = type(o)
@@ -55,8 +65,13 @@ def dump_func(f):
     for n in code.co_names:
         r = f.func_globals.get(n)
         if r is not None:
-            glob[n] = dump_object(r)
-    closure = f.func_closure and tuple(dump_object(c.cell_contents) for c in f.func_closure) or None 
+            if r is f:
+                # Prevent infinite recursion when dumping a recursive function
+                glob[n] = dump_object(RECURSIVE_FUNCTION_PLACEHOLDER)
+            else:
+                glob[n] = dump_object(r)
+
+    closure = f.func_closure and tuple(dump_object(c.cell_contents) for c in f.func_closure) or None
     return 0, marshal.dumps((code, glob, f.func_name, f.func_defaults, closure))
 
 def load_func((flag, bytes)):
@@ -65,8 +80,16 @@ def load_func((flag, bytes)):
     code, glob, name, defaults, closure = marshal.loads(bytes)
     glob = dict((k, load_object(v)) for k,v in glob.items())
     glob['__builtins__'] = __builtins__
+    # Simulate a function pointer, so we can create globals that refer to the function itself
+    func = []
+    def selfCall(*args, **kwargs): return func[0](*args, **kwargs)
+    # Replace the recursive function placeholders with this simulated function pointer
+    for (key, value) in glob.items():
+        if value == RECURSIVE_FUNCTION_PLACEHOLDER:
+            glob[key] = selfCall
     closure = closure and reconstruct_closure([load_object(c) for c in closure]) or None
-    return new.function(code, glob, name, defaults, closure)
+    func.append(new.function(code, glob, name, defaults, closure))
+    return func[0]
 
 def reconstruct_closure(values):
     ns = range(len(values))
@@ -114,3 +137,7 @@ if __name__ == "__main__":
     #print globals()
     print f(2)
     print ff(2)
+
+    # Test recursive functions
+    def fib(n): return n if n <= 1 else fib(n-1) + fib(n-2)
+    assert fib(8) == load_func(dump_func(fib))(8)


### PR DESCRIPTION
This patch adds support for serialization of recursive functions with `dump_func()`.  Previously, trying to serialize a recursive function resulted in infinite recursion:

``` python
>>> from serialize import dump_func, load_func
>>> def fib(n): return n if n <= 1 else fib(n-1) + fib(n-2)
... 
>>> dump_func(fib)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "serialize.py", line 58, in dump_func
    glob[n] = dump_object(r)
  File "serialize.py", line 25, in dump_object
    return 1, dump_func(o)
  File "serialize.py", line 58, in dump_func
    glob[n] = dump_object(r)
  File "serialize.py", line 25, in dump_object
    return 1, dump_func(o)
   ...
  File "serialize.py", line 47, in dump_func
    if f.__module__ != '__main__':
RuntimeError: maximum recursion depth exceeded in cmp
```

The infinite recursion occurs because the function object itself appears in its own globals dictionary under the name `fib`.

This patch addresses this issue by replacing self-references with special placeholder objects before serialization.  When deserializing a function, the placeholders are replaced by a wrapper function that calls a function stored in a list.  This simulates a function pointer and allows a reference to the deserialized function to appear in that function's globals dictionary when it is constructed with `new.function()`.

After applying this patch, the recursive Fibonacci function is serializable:

``` python
>>> dump_func(fib)
(0, '(\x05\x00\x00\x00c\x01\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00C\x00\x00\x00s,\x00\x00\x00|\x00\x00d\x01\x00k\x01\x00r\x10\x00|\x00\x00St\x00\x00|\x00\x00d\x01\x00\x18\x83\x01\x00t\x00\x00|\x00\x00d\x02\x00\x18\x83\x01\x00\x17S(\x03\x00\x00\x00Ni\x01\x00\x00\x00i\x02\x00\x00\x00(\x01\x00\x00\x00t\x03\x00\x00\x00fib(\x01\x00\x00\x00t\x01\x00\x00\x00n(\x00\x00\x00\x00(\x00\x00\x00\x00s\x07\x00\x00\x00<stdin>R\x00\x00\x00\x00\x01\x00\x00\x00s\x00\x00\x00\x00{R\x00\x00\x00\x00(\x02\x00\x00\x00i\x03\x00\x00\x00s5\x00\x00\x00\x80\x02cserialize\nRecursiveFunctionPlaceholder\nq\x01)\x81q\x02}q\x03b.0R\x00\x00\x00\x00NN')
>>> load_func(dump_func(fib))(3)
2
```
