### PR TITLE
docs: fix simple typo, resourses -> resources

### DIFF
--- a/tools/scheduler.py
+++ b/tools/scheduler.py
@@ -983,7 +983,7 @@ if __name__ == '__main__':
         # if any thread of sched may use lock or call driver, join it first
         driver.stop(False)
         driver.join()
-        # mesos resourses are released, and no racer for lock any more
+        # mesos resources are released, and no racer for lock any more
         sched.cleanup()
         ctx.term()
         sys.exit(sched.ec)


### PR DESCRIPTION
There is a small typo in tools/scheduler.py.

Should read `resources` rather than `resourses`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md